### PR TITLE
Included locationPinText property

### DIFF
--- a/lib/open_street_map_search_and_pick.dart
+++ b/lib/open_street_map_search_and_pick.dart
@@ -20,6 +20,8 @@ class OpenStreetMapSearchAndPick extends StatefulWidget {
   final Color buttonColor;
   final Color buttonTextColor;
   final Color locationPinIconColor;
+  final String? locationPinText;
+  final TextStyle? locationPinTextStyle;
   final String buttonText;
   final String hintText;
 
@@ -31,12 +33,14 @@ class OpenStreetMapSearchAndPick extends StatefulWidget {
     Key? key,
     required this.center,
     required this.onPicked,
-    this.zoomOutIcon =  Icons.zoom_out_map,
-    this.zoomInIcon =Icons.zoom_in_map,
+    this.zoomOutIcon = Icons.zoom_out_map,
+    this.zoomInIcon = Icons.zoom_in_map,
     this.currentLocationIcon = Icons.my_location,
     this.onGetCurrentLocationPressed = nopFunction,
     this.buttonColor = Colors.blue,
     this.locationPinIconColor = Colors.blue,
+    this.locationPinText,
+    this.locationPinTextStyle,
     this.buttonTextColor = Colors.white,
     this.buttonText = 'Set Current Location',
     this.hintText = 'Search Location',
@@ -159,27 +163,24 @@ class _OpenStreetMapSearchAndPickState
               ),
             ],
           )),
-          Positioned(
-              top: MediaQuery.of(context).size.height * 0.5,
-              left: 0,
-              right: 0,
-              child: IgnorePointer(
-                child: Center(
-                  child: StatefulBuilder(builder: (context, setState) {
-                    return Text(
-                      _searchController.text,
-                      textAlign: TextAlign.center,
-                    );
-                  }),
-                ),
-              )),
           Positioned.fill(
               child: IgnorePointer(
             child: Center(
-              child: Icon(
-                Icons.location_pin,
-                size: 50,
-                color: widget.locationPinIconColor,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(widget.locationPinText ?? _searchController.text,
+                      style: widget.locationPinTextStyle,
+                      textAlign: TextAlign.center),
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 50),
+                    child: Icon(
+                      Icons.location_pin,
+                      size: 50,
+                      color: widget.locationPinIconColor,
+                    ),
+                  ),
+                ],
               ),
             ),
           )),
@@ -194,7 +195,7 @@ class _OpenStreetMapSearchAndPickState
                       _mapController.center, _mapController.zoom + 1);
                 },
                 child: Icon(
-                widget.zoomInIcon,
+                  widget.zoomInIcon,
                   color: widget.buttonTextColor,
                 ),
               )),
@@ -209,7 +210,7 @@ class _OpenStreetMapSearchAndPickState
                       _mapController.center, _mapController.zoom - 1);
                 },
                 child: Icon(
-                widget.zoomOutIcon,
+                  widget.zoomOutIcon,
                   color: widget.buttonTextColor,
                 ),
               )),
@@ -235,7 +236,7 @@ class _OpenStreetMapSearchAndPickState
                   }
                 },
                 child: Icon(
-                widget.currentLocationIcon ,
+                  widget.currentLocationIcon,
                   color: widget.buttonTextColor,
                 ),
               )),


### PR DESCRIPTION
Included locationPinText property on OpenStreetMapSearchAndPick widget, to customize a label above location pin icon. When no text is provided, default is address text.

Resolves #12 